### PR TITLE
[FEAT] 가게 기본 CRUD 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/f1/fastone/store/controller/StoreCategoryController.java
+++ b/src/main/java/com/f1/fastone/store/controller/StoreCategoryController.java
@@ -19,7 +19,6 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/store-categories")
-@Tag(name = "StoreCategory", description = "StoreCategory 등록 API")
 public class StoreCategoryController {
 
     private final StoreCategoryService storeCategoryService;

--- a/src/main/java/com/f1/fastone/store/controller/StoreController.java
+++ b/src/main/java/com/f1/fastone/store/controller/StoreController.java
@@ -1,0 +1,86 @@
+package com.f1.fastone.store.controller;
+
+import com.f1.fastone.common.auth.security.UserDetailsImpl;
+import com.f1.fastone.common.dto.ApiResponse;
+import com.f1.fastone.store.dto.request.StoreCreateRequestDto;
+import com.f1.fastone.store.dto.request.StoreUpdateRequestDto;
+import com.f1.fastone.store.dto.response.StoreResponseDto;
+import com.f1.fastone.store.service.StoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stores")
+@Tag(name = "Store", description = "가게 관리 API")
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
+    @Operation(summary = "가게 등록", description = "새로운 가게를 등록합니다. CUSTOMER는 OWNER로 승격됩니다.")
+    public ResponseEntity<ApiResponse<StoreResponseDto>> createStore(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody @Valid StoreCreateRequestDto request) {
+
+        ApiResponse<StoreResponseDto> response = storeService.createStore(userDetails.getUsername(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{storeId}")
+    @Operation(summary = "가게 조회", description = "특정 ID의 가게 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<StoreResponseDto>> getStore(@PathVariable UUID storeId) {
+        ApiResponse<StoreResponseDto> response = storeService.getStore(storeId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/my-area")
+    @Operation(summary = "내 지역 가게 조회", description = "사용자 주소 기반으로 해당 지역의 가게 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<StoreResponseDto>>> getStoresByUserAddress(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        ApiResponse<List<StoreResponseDto>> response = storeService.getStoresByUserAddress(userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    @Operation(summary = "가게 전체 조회 (관리자용)", description = "관리자만 접근 가능한 전체 가게 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<StoreResponseDto>>> getAllStores() {
+        ApiResponse<List<StoreResponseDto>> response = storeService.getAllStores();
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{storeId}")
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    @Operation(summary = "가게 수정", description = "가게 정보를 수정합니다. 본인 가게 또는 관리자만 수정 가능합니다.")
+    public ResponseEntity<ApiResponse<StoreResponseDto>> updateStore(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable UUID storeId,
+            @RequestBody @Valid StoreUpdateRequestDto request) {
+
+        ApiResponse<StoreResponseDto> response = storeService.updateStore(userDetails.getUsername(), storeId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{storeId}")
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    @Operation(summary = "가게 삭제", description = "가게를 삭제합니다. 본인 가게 또는 관리자만 삭제 가능합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteStore(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable UUID storeId) {
+
+        ApiResponse<Void> response = storeService.deleteStore(userDetails.getUsername(), storeId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/f1/fastone/store/controller/StoreController.java
+++ b/src/main/java/com/f1/fastone/store/controller/StoreController.java
@@ -3,10 +3,13 @@ package com.f1.fastone.store.controller;
 import com.f1.fastone.common.auth.security.UserDetailsImpl;
 import com.f1.fastone.common.dto.ApiResponse;
 import com.f1.fastone.store.dto.request.StoreCreateRequestDto;
+import com.f1.fastone.store.dto.request.StoreSearchRequestDto;
 import com.f1.fastone.store.dto.request.StoreUpdateRequestDto;
 import com.f1.fastone.store.dto.response.StoreResponseDto;
+import com.f1.fastone.store.dto.response.StoreSearchPageResponseDto;
 import com.f1.fastone.store.service.StoreService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +50,7 @@ public class StoreController {
         return ResponseEntity.ok(response);
     }
 
-    // 내 지역 가게 목록 조회
+    // 내 지역 가게 목록 조회 (기존)
     @GetMapping("/my-area")
     @Operation(summary = "내 지역 가게 조회", description = "사용자 주소 기반으로 해당 지역의 가게 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<StoreResponseDto>>> getStoresByUserAddress(
@@ -56,12 +59,79 @@ public class StoreController {
         return ResponseEntity.ok(response);
     }
 
-    // 전체 가게 목록 조회
+    // 내 지역 가게 검색 및 필터링 (고객용)
+    @GetMapping("/search")
+    @Operation(summary = "가게 검색 (고객용)", 
+               description = "사용자 주소 기반으로 가게를 검색합니다. 키워드, 카테고리, 페이징, 정렬을 지원합니다.")
+    public ResponseEntity<ApiResponse<StoreSearchPageResponseDto>> searchStores(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "검색 키워드 (가게명)", example = "BBQ")
+            @RequestParam(required = false) String keyword,
+            
+            @Parameter(description = "카테고리 ID", example = "1")
+            @RequestParam(required = false) Long categoryId,
+            
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") Integer page,
+            
+            @Parameter(description = "페이지 크기 (10, 30, 50)", example = "10")
+            @RequestParam(defaultValue = "10") Integer size,
+            
+            @Parameter(description = "정렬 기준 (createdAt, scoreAvg)", example = "createdAt")
+            @RequestParam(defaultValue = "createdAt") String sortBy) {
+        
+        StoreSearchRequestDto searchRequest = StoreSearchRequestDto.builder()
+                .keyword(keyword)
+                .categoryId(categoryId)
+                .page(page)
+                .size(size)
+                .sortBy(sortBy)
+                .build();
+        
+        ApiResponse<StoreSearchPageResponseDto> response = storeService.searchStoresByUserAddress(
+                userDetails.getUsername(), searchRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    // 전체 가게 목록 조회 (기존)
     @GetMapping
     @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
     @Operation(summary = "가게 전체 조회 (관리자용)", description = "관리자만 접근 가능한 전체 가게 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<StoreResponseDto>>> getAllStores() {
         ApiResponse<List<StoreResponseDto>> response = storeService.getAllStores();
+        return ResponseEntity.ok(response);
+    }
+
+    // 관리자용 전체 가게 검색 및 필터링
+    @GetMapping("/admin/search")
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    @Operation(summary = "가게 검색 (관리자용)", 
+               description = "관리자만 접근 가능한 전체 가게 검색입니다. 키워드, 카테고리, 페이징, 정렬을 지원합니다.")
+    public ResponseEntity<ApiResponse<StoreSearchPageResponseDto>> searchAllStores(
+            @Parameter(description = "검색 키워드 (가게명)", example = "치킨")
+            @RequestParam(required = false) String keyword,
+            
+            @Parameter(description = "카테고리 ID", example = "2")
+            @RequestParam(required = false) Long categoryId,
+            
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") Integer page,
+            
+            @Parameter(description = "페이지 크기 (10, 30, 50)", example = "30")
+            @RequestParam(defaultValue = "10") Integer size,
+            
+            @Parameter(description = "정렬 기준 (createdAt, scoreAvg)", example = "scoreAvg")
+            @RequestParam(defaultValue = "createdAt") String sortBy) {
+        
+        StoreSearchRequestDto searchRequest = StoreSearchRequestDto.builder()
+                .keyword(keyword)
+                .categoryId(categoryId)
+                .page(page)
+                .size(size)
+                .sortBy(sortBy)
+                .build();
+        
+        ApiResponse<StoreSearchPageResponseDto> response = storeService.searchAllStores(searchRequest);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/f1/fastone/store/controller/StoreController.java
+++ b/src/main/java/com/f1/fastone/store/controller/StoreController.java
@@ -27,6 +27,7 @@ public class StoreController {
 
     private final StoreService storeService;
 
+    // 새로운 가게 등록
     @PostMapping
     @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
     @Operation(summary = "가게 등록", description = "새로운 가게를 등록합니다. CUSTOMER는 OWNER로 승격됩니다.")
@@ -38,6 +39,7 @@ public class StoreController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    // 가게 단일 조회
     @GetMapping("/{storeId}")
     @Operation(summary = "가게 조회", description = "특정 ID의 가게 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<StoreResponseDto>> getStore(@PathVariable UUID storeId) {
@@ -45,6 +47,7 @@ public class StoreController {
         return ResponseEntity.ok(response);
     }
 
+    // 내 지역 가게 목록 조회
     @GetMapping("/my-area")
     @Operation(summary = "내 지역 가게 조회", description = "사용자 주소 기반으로 해당 지역의 가게 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<StoreResponseDto>>> getStoresByUserAddress(
@@ -53,6 +56,7 @@ public class StoreController {
         return ResponseEntity.ok(response);
     }
 
+    // 전체 가게 목록 조회
     @GetMapping
     @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
     @Operation(summary = "가게 전체 조회 (관리자용)", description = "관리자만 접근 가능한 전체 가게 목록을 조회합니다.")
@@ -61,6 +65,7 @@ public class StoreController {
         return ResponseEntity.ok(response);
     }
 
+    // 가게 정보 수정
     @PutMapping("/{storeId}")
     @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
     @Operation(summary = "가게 수정", description = "가게 정보를 수정합니다. 본인 가게 또는 관리자만 수정 가능합니다.")
@@ -73,6 +78,7 @@ public class StoreController {
         return ResponseEntity.ok(response);
     }
 
+    // 가게 삭제
     @DeleteMapping("/{storeId}")
     @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
     @Operation(summary = "가게 삭제", description = "가게를 삭제합니다. 본인 가게 또는 관리자만 삭제 가능합니다.")

--- a/src/main/java/com/f1/fastone/store/controller/StoreController.java
+++ b/src/main/java/com/f1/fastone/store/controller/StoreController.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/stores")
-@Tag(name = "Store", description = "가게 관리 API")
 public class StoreController {
 
     private final StoreService storeService;
@@ -50,7 +49,7 @@ public class StoreController {
         return ResponseEntity.ok(response);
     }
 
-    // 내 지역 가게 목록 조회 (기존)
+    // 내 지역 가게 목록 조회
     @GetMapping("/my-area")
     @Operation(summary = "내 지역 가게 조회", description = "사용자 주소 기반으로 해당 지역의 가게 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<StoreResponseDto>>> getStoresByUserAddress(
@@ -93,7 +92,7 @@ public class StoreController {
         return ResponseEntity.ok(response);
     }
 
-    // 전체 가게 목록 조회 (기존)
+    // 전체 가게 목록 조회
     @GetMapping
     @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
     @Operation(summary = "가게 전체 조회 (관리자용)", description = "관리자만 접근 가능한 전체 가게 목록을 조회합니다.")

--- a/src/main/java/com/f1/fastone/store/dto/request/StoreCreateRequestDto.java
+++ b/src/main/java/com/f1/fastone/store/dto/request/StoreCreateRequestDto.java
@@ -1,0 +1,54 @@
+package com.f1.fastone.store.dto.request;
+
+import com.f1.fastone.store.entity.Store;
+import com.f1.fastone.store.entity.StoreCategory;
+import com.f1.fastone.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.Length;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+public record StoreCreateRequestDto(
+        @NotBlank(message = "가게 이름은 필수입니다.")
+        @Size(max = 120, message = "가게 이름은 120자를 초과할 수 없습니다.")
+        String name,
+
+        @Length(max = 20, message = "전화번호는 20자를 초과할 수 없습니다.")
+        String phone,
+
+        @Length(max = 10, message = "우편번호는 10자를 초과할 수 없습니다.")
+        String postalCode,
+
+        @Length(max = 120, message = "도시명은 120자를 초과할 수 없습니다.")
+        String city,
+
+        String address,
+        String addressDetail,
+
+        BigDecimal latitude,
+        BigDecimal longitude,
+
+        LocalTime openTime,
+        LocalTime closeTime,
+
+        Long categoryId
+) {
+    public Store toEntity(User owner, StoreCategory category) {
+        return Store.builder()
+                .name(this.name)
+                .phone(this.phone)
+                .postalCode(this.postalCode)
+                .city(this.city)
+                .address(this.address)
+                .addressDetail(this.addressDetail)
+                .latitude(this.latitude)
+                .longitude(this.longitude)
+                .openTime(this.openTime)
+                .closeTime(this.closeTime)
+                .owner(owner)
+                .category(category)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/fastone/store/dto/request/StoreSearchRequestDto.java
+++ b/src/main/java/com/f1/fastone/store/dto/request/StoreSearchRequestDto.java
@@ -8,12 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 가게 검색 요청 DTO
- * - 상호명, 주소로 검색
- * - 카테고리별, 운영상태별 필터링
- * - 페이징 및 정렬 옵션 제공
- */
 @Getter
 @Builder
 @NoArgsConstructor
@@ -29,8 +23,6 @@ public class StoreSearchRequestDto {
     private String keyword;
     
     private Long categoryId;
-    
-    private Boolean isOpen;
     
     @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.")
     private Integer page;
@@ -83,8 +75,4 @@ public class StoreSearchRequestDto {
         return categoryId != null;
     }
     
-    // 운영상태 필터가 있는지 확인
-    public boolean hasStatusFilter() {
-        return isOpen != null;
-    }
 }

--- a/src/main/java/com/f1/fastone/store/dto/request/StoreSearchRequestDto.java
+++ b/src/main/java/com/f1/fastone/store/dto/request/StoreSearchRequestDto.java
@@ -1,0 +1,90 @@
+package com.f1.fastone.store.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 가게 검색 요청 DTO
+ * - 상호명, 주소로 검색
+ * - 카테고리별, 운영상태별 필터링
+ * - 페이징 및 정렬 옵션 제공
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreSearchRequestDto {
+
+    // 가게 검색 요청 DTO
+    // 검색: 상호명, 주소
+    // 필터링: 카테고리별, 운영상태별 필터링
+    // 페이징, 정렬
+    
+    @Size(max = 100, message = "검색어는 100자를 초과할 수 없습니다.")
+    private String keyword;
+    
+    private Long categoryId;
+    
+    private Boolean isOpen;
+    
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.")
+    private Integer page;
+    
+    @Min(value = 10, message = "페이지 크기는 최소 10입니다.")
+    @Max(value = 50, message = "페이지 크기는 최대 50입니다.")
+    private Integer size;
+    
+    private String sortBy;
+    
+    // 기본값 설정 및 유효성 검증을 위한 메서드
+    public void validateAndSetDefaults() {
+    
+        // 페이지 번호 기본값 설정
+        if (this.page == null) {
+            this.page = 0;
+        }
+        
+        // 페이지 크기 기본값 설정 및 유효성 검증
+        if (this.size == null) {
+            this.size = 10;
+        } else {
+            // 10, 30, 50 중 하나가 아니면 10으로 설정
+            if (this.size != 10 && this.size != 30 && this.size != 50) {
+                this.size = 10;
+            }
+        }
+        
+        // 정렬 기준 기본값 설정
+        if (this.sortBy == null || this.sortBy.trim().isEmpty()) {
+            this.sortBy = "createdAt";
+        }
+        
+        // 검색어 공백 처리
+        if (this.keyword != null) {
+            this.keyword = this.keyword.trim();
+            if (this.keyword.isEmpty()) {
+                this.keyword = null;
+            }
+        }
+    }
+    
+    // 검색어가 있는지 확인
+    public boolean hasKeyword() {
+        return keyword != null && !keyword.trim().isEmpty();
+    }
+    
+    // 카테고리 필터가 있는지 확인
+    public boolean hasCategoryFilter() {
+        return categoryId != null;
+    }
+    
+    // 운영상태 필터가 있는지 확인
+    public boolean hasStatusFilter() {
+        return isOpen != null;
+    }
+}

--- a/src/main/java/com/f1/fastone/store/dto/request/StoreUpdateRequestDto.java
+++ b/src/main/java/com/f1/fastone/store/dto/request/StoreUpdateRequestDto.java
@@ -1,0 +1,35 @@
+package com.f1.fastone.store.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.Length;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+public record StoreUpdateRequestDto(
+        @NotBlank(message = "가게 이름은 필수입니다.")
+        @Size(max = 120, message = "가게 이름은 120자를 초과할 수 없습니다.")
+        String name,
+
+        @Length(max = 20, message = "전화번호는 20자를 초과할 수 없습니다.")
+        String phone,
+
+        @Length(max = 10, message = "우편번호는 10자를 초과할 수 없습니다.")
+        String postalCode,
+
+        @Length(max = 120, message = "도시명은 120자를 초과할 수 없습니다.")
+        String city,
+
+        String address,
+        String addressDetail,
+
+        BigDecimal latitude,
+        BigDecimal longitude,
+
+        LocalTime openTime,
+        LocalTime closeTime,
+
+        Long categoryId
+) {
+}

--- a/src/main/java/com/f1/fastone/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/com/f1/fastone/store/dto/response/StoreResponseDto.java
@@ -1,0 +1,46 @@
+package com.f1.fastone.store.dto.response;
+
+import com.f1.fastone.store.entity.Store;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+public record StoreResponseDto(
+        UUID id,
+        String name,
+        String phone,
+        String postalCode,
+        String city,
+        String address,
+        String addressDetail,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        LocalTime openTime,
+        LocalTime closeTime,
+        String categoryName,
+        String ownerUsername,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static StoreResponseDto fromEntity(Store store) {
+        return new StoreResponseDto(
+                store.getId(),
+                store.getName(),
+                store.getPhone(),
+                store.getPostalCode(),
+                store.getCity(),
+                store.getAddress(),
+                store.getAddressDetail(),
+                store.getLatitude(),
+                store.getLongitude(),
+                store.getOpenTime(),
+                store.getCloseTime(),
+                store.getCategory() != null ? store.getCategory().getStoreCategoryName() : null,
+                store.getOwner().getUsername(),
+                store.getCreatedAt(),
+                store.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/f1/fastone/store/dto/response/StoreSearchPageResponseDto.java
+++ b/src/main/java/com/f1/fastone/store/dto/response/StoreSearchPageResponseDto.java
@@ -1,0 +1,47 @@
+package com.f1.fastone.store.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 가게 검색 페이징 응답 DTO
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreSearchPageResponseDto {
+    
+    private List<StoreSearchResponseDto> stores;
+    private int currentPage;
+    private int totalPages;
+    private long totalElements;
+    private int currentPageSize;
+    private boolean isFirst;
+    private boolean isLast;
+    private boolean hasNext;
+    private boolean hasPrevious;
+    
+    // Spring Data의 Page 객체로부터 응답 DTO 생성
+    public static <T> StoreSearchPageResponseDto fromPage(
+            org.springframework.data.domain.Page<T> page,
+            java.util.function.Function<T, StoreSearchResponseDto> converter) {
+        
+        List<StoreSearchResponseDto> stores = page.getContent().stream()
+                .map(converter)
+                .toList();
+        
+        return StoreSearchPageResponseDto.builder()
+                .stores(stores)
+                .currentPage(page.getNumber())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .currentPageSize(page.getNumberOfElements())
+                .isFirst(page.isFirst())
+                .isLast(page.isLast())
+                .hasNext(page.hasNext())
+                .hasPrevious(page.hasPrevious())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/fastone/store/dto/response/StoreSearchResponseDto.java
+++ b/src/main/java/com/f1/fastone/store/dto/response/StoreSearchResponseDto.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-// 가게 검색 결과 응답 DTO(검색된 가게 목록, 페이징 정보)
 @Getter
 @Builder
 @NoArgsConstructor
@@ -43,12 +42,12 @@ public class StoreSearchResponseDto {
                 .longitude(store.getLongitude())
                 .openTime(store.getOpenTime())
                 .closeTime(store.getCloseTime())
-                .isOpen(null) // Store 엔티티에 isOpen 필드가 없음 - 추후 추가 예정
+                .isOpen(true) // 기본값으로 영업중으로 설정
                 .categoryId(store.getCategory() != null ? store.getCategory().getId() : null)
                 .categoryName(store.getCategory() != null ? store.getCategory().getStoreCategoryName() : null)
                 .averageRating(null) // 추후 StoreRating 연동 시 구현
                 .reviewCount(0) // 추후 Review 도메인 연동 시 구현
-                .favoriteCount(0) // Store 엔티티에 favoriteCount 필드가 없음 - 추후 추가 예정
+                .favoriteCount(0) // 추후 수정
                 .build();
     }
 }

--- a/src/main/java/com/f1/fastone/store/dto/response/StoreSearchResponseDto.java
+++ b/src/main/java/com/f1/fastone/store/dto/response/StoreSearchResponseDto.java
@@ -1,0 +1,54 @@
+package com.f1.fastone.store.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 가게 검색 결과 응답 DTO(검색된 가게 목록, 페이징 정보)
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreSearchResponseDto {
+    
+    private UUID storeId;
+    private String name;
+    private String phone;
+    private String city;
+    private String address;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private LocalTime openTime;
+    private LocalTime closeTime;
+    private Boolean isOpen;
+    private Long categoryId;
+    private String categoryName;
+    private BigDecimal averageRating;
+    private Integer reviewCount;
+    private Integer favoriteCount;
+    
+    // Store 엔티티로부터 응답 DTO 생성
+    public static StoreSearchResponseDto fromEntity(com.f1.fastone.store.entity.Store store) {
+        return StoreSearchResponseDto.builder()
+                .storeId(store.getId())
+                .name(store.getName())
+                .phone(store.getPhone())
+                .city(store.getCity())
+                .address(store.getAddress())
+                .latitude(store.getLatitude())
+                .longitude(store.getLongitude())
+                .openTime(store.getOpenTime())
+                .closeTime(store.getCloseTime())
+                .isOpen(null) // Store 엔티티에 isOpen 필드가 없음 - 추후 추가 예정
+                .categoryId(store.getCategory() != null ? store.getCategory().getId() : null)
+                .categoryName(store.getCategory() != null ? store.getCategory().getStoreCategoryName() : null)
+                .averageRating(null) // 추후 StoreRating 연동 시 구현
+                .reviewCount(0) // 추후 Review 도메인 연동 시 구현
+                .favoriteCount(0) // Store 엔티티에 favoriteCount 필드가 없음 - 추후 추가 예정
+                .build();
+    }
+}

--- a/src/main/java/com/f1/fastone/store/entity/Store.java
+++ b/src/main/java/com/f1/fastone/store/entity/Store.java
@@ -77,4 +77,21 @@ public class Store extends BaseEntity {
     public void addStoreRating(StoreRating storeRating) {
         this.storeRating = storeRating;
     }
+
+    public void update(String name, String phone, String postalCode, String city,
+                       String address, String addressDetail, BigDecimal latitude,
+                       BigDecimal longitude, LocalTime openTime, LocalTime closeTime,
+                       StoreCategory category) {
+        this.name = name;
+        this.phone = phone;
+        this.postalCode = postalCode;
+        this.city = city;
+        this.address = address;
+        this.addressDetail = addressDetail;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+        this.category = category;
+    }
 }

--- a/src/main/java/com/f1/fastone/store/repository/StoreRepository.java
+++ b/src/main/java/com/f1/fastone/store/repository/StoreRepository.java
@@ -5,7 +5,11 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.f1.fastone.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.f1.fastone.store.entity.Store;
 
@@ -18,4 +22,17 @@ public interface StoreRepository extends JpaRepository<Store, UUID> {
     
     // 사용자 주소의 city와 일치하는 가게 조회
     List<Store> findByCityAndDeletedAtIsNull(String city);
+
+    // 가게명 기반 키워드 검색(페이징)
+    Page<Store> findByNameContainingIgnoreCaseAndDeletedAtIsNull(String name, Pageable pageable);
+
+    // 카테고리별 가게 목록 조회(페이징)
+    Page<Store> findByCategoryIdAndDeletedAtIsNull(Long categoryId, Pageable pageable);
+
+    // 특정 가게 카테고리 내의 가게명 검색(페이징)
+    Page<Store> findByNameContainingIgnoreCaseAndCategoryIdAndDeletedAtIsNull(
+            String name, Long categoryId, Pageable pageable);
+
+    // 관리자용 전체 가게 조회(페이징)
+    Page<Store> findAllByDeletedAtIsNull(Pageable pageable);
 }

--- a/src/main/java/com/f1/fastone/store/repository/StoreRepository.java
+++ b/src/main/java/com/f1/fastone/store/repository/StoreRepository.java
@@ -1,5 +1,7 @@
 package com.f1.fastone.store.repository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import com.f1.fastone.user.entity.User;
@@ -9,4 +11,11 @@ import com.f1.fastone.store.entity.Store;
 
 public interface StoreRepository extends JpaRepository<Store, UUID> {
     Store findByOwner(User user);
+    
+    Optional<Store> findByIdAndDeletedAtIsNull(UUID id);
+    
+    List<Store> findAllByDeletedAtIsNull();
+    
+    // 사용자 주소의 city와 일치하는 가게 조회
+    List<Store> findByCityAndDeletedAtIsNull(String city);
 }

--- a/src/main/java/com/f1/fastone/store/service/StoreService.java
+++ b/src/main/java/com/f1/fastone/store/service/StoreService.java
@@ -32,6 +32,7 @@ public class StoreService {
     private final UserRepository userRepository;
     private final UserAddressRepository userAddressRepository;
 
+    // 새로운 가게 생성
     @Transactional
     public ApiResponse<StoreResponseDto> createStore(String username, StoreCreateRequestDto dto) {
         // User 조회
@@ -43,7 +44,7 @@ public class StoreService {
             user.updateRole(UserRole.OWNER);
         }
 
-        // StoreCategory 조회 (선택사항)
+        // StoreCategory 조회
         StoreCategory category = null;
         if (dto.categoryId() != null) {
             category = storeCategoryRepository.findById(dto.categoryId())
@@ -57,6 +58,7 @@ public class StoreService {
         return ApiResponse.created(StoreResponseDto.fromEntity(savedStore));
     }
 
+    // 단일 가게 조회
     public ApiResponse<StoreResponseDto> getStore(UUID id) {
         Store store = storeRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_NOT_FOUND));
@@ -64,6 +66,7 @@ public class StoreService {
         return ApiResponse.success(StoreResponseDto.fromEntity(store));
     }
 
+    // 모든 가게 목록 조회 (관리자용)
     public ApiResponse<List<StoreResponseDto>> getAllStores() {
         List<Store> stores = storeRepository.findAllByDeletedAtIsNull();
         List<StoreResponseDto> responseDtos = stores.stream()
@@ -73,6 +76,7 @@ public class StoreService {
         return ApiResponse.success(responseDtos);
     }
 
+    // 가게 정보 수정
     @Transactional
     public ApiResponse<StoreResponseDto> updateStore(String username, UUID id, StoreUpdateRequestDto dto) {
         // User 조회
@@ -89,7 +93,7 @@ public class StoreService {
             throw new EntityNotFoundException(ErrorCode.ACCESS_DENIED);
         }
 
-        // StoreCategory 조회 (선택사항)
+        // StoreCategory 조회
         StoreCategory category = null;
         if (dto.categoryId() != null) {
             category = storeCategoryRepository.findById(dto.categoryId())
@@ -115,6 +119,7 @@ public class StoreService {
         return ApiResponse.success(StoreResponseDto.fromEntity(updatedStore));
     }
 
+    // 가게 삭제
     @Transactional
     public ApiResponse<Void> deleteStore(String username, UUID id) {
         // User 조회

--- a/src/main/java/com/f1/fastone/store/service/StoreService.java
+++ b/src/main/java/com/f1/fastone/store/service/StoreService.java
@@ -1,0 +1,158 @@
+package com.f1.fastone.store.service;
+
+import com.f1.fastone.common.dto.ApiResponse;
+import com.f1.fastone.common.exception.ErrorCode;
+import com.f1.fastone.common.exception.custom.EntityNotFoundException;
+import com.f1.fastone.store.dto.request.StoreCreateRequestDto;
+import com.f1.fastone.store.dto.request.StoreUpdateRequestDto;
+import com.f1.fastone.store.dto.response.StoreResponseDto;
+import com.f1.fastone.store.entity.Store;
+import com.f1.fastone.store.entity.StoreCategory;
+import com.f1.fastone.store.repository.StoreCategoryRepository;
+import com.f1.fastone.store.repository.StoreRepository;
+import com.f1.fastone.user.entity.User;
+import com.f1.fastone.user.entity.UserAddress;
+import com.f1.fastone.user.entity.UserRole;
+import com.f1.fastone.user.repository.UserAddressRepository;
+import com.f1.fastone.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+    private final StoreCategoryRepository storeCategoryRepository;
+    private final UserRepository userRepository;
+    private final UserAddressRepository userAddressRepository;
+
+    @Transactional
+    public ApiResponse<StoreResponseDto> createStore(String username, StoreCreateRequestDto dto) {
+        // User 조회
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        // CUSTOMER → OWNER 역할 승격
+        if (user.getRole() == UserRole.CUSTOMER) {
+            user.updateRole(UserRole.OWNER);
+        }
+
+        // StoreCategory 조회 (선택사항)
+        StoreCategory category = null;
+        if (dto.categoryId() != null) {
+            category = storeCategoryRepository.findById(dto.categoryId())
+                    .orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_CATEGORY_NOT_FOUND));
+        }
+
+        // Store 생성
+        Store store = dto.toEntity(user, category);
+        Store savedStore = storeRepository.save(store);
+
+        return ApiResponse.created(StoreResponseDto.fromEntity(savedStore));
+    }
+
+    public ApiResponse<StoreResponseDto> getStore(UUID id) {
+        Store store = storeRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_NOT_FOUND));
+
+        return ApiResponse.success(StoreResponseDto.fromEntity(store));
+    }
+
+    public ApiResponse<List<StoreResponseDto>> getAllStores() {
+        List<Store> stores = storeRepository.findAllByDeletedAtIsNull();
+        List<StoreResponseDto> responseDtos = stores.stream()
+                .map(StoreResponseDto::fromEntity)
+                .toList();
+
+        return ApiResponse.success(responseDtos);
+    }
+
+    @Transactional
+    public ApiResponse<StoreResponseDto> updateStore(String username, UUID id, StoreUpdateRequestDto dto) {
+        // User 조회
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        // Store 조회
+        Store store = storeRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_NOT_FOUND));
+
+        // 권한 검증: owner 본인 or MANAGER or MASTER
+        if (user.getRole() != UserRole.MANAGER && user.getRole() != UserRole.MASTER 
+            && !store.getOwner().getUsername().equals(username)) {
+            throw new EntityNotFoundException(ErrorCode.ACCESS_DENIED);
+        }
+
+        // StoreCategory 조회 (선택사항)
+        StoreCategory category = null;
+        if (dto.categoryId() != null) {
+            category = storeCategoryRepository.findById(dto.categoryId())
+                    .orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_CATEGORY_NOT_FOUND));
+        }
+
+        // Store 수정
+        store.update(
+                dto.name(),
+                dto.phone(),
+                dto.postalCode(),
+                dto.city(),
+                dto.address(),
+                dto.addressDetail(),
+                dto.latitude(),
+                dto.longitude(),
+                dto.openTime(),
+                dto.closeTime(),
+                category
+        );
+
+        Store updatedStore = storeRepository.save(store);
+        return ApiResponse.success(StoreResponseDto.fromEntity(updatedStore));
+    }
+
+    @Transactional
+    public ApiResponse<Void> deleteStore(String username, UUID id) {
+        // User 조회
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        // Store 조회
+        Store store = storeRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_NOT_FOUND));
+
+        // 권한 검증: owner 본인 or MANAGER or MASTER
+        if (user.getRole() != UserRole.MANAGER && user.getRole() != UserRole.MASTER 
+            && !store.getOwner().getUsername().equals(username)) {
+            throw new EntityNotFoundException(ErrorCode.ACCESS_DENIED);
+        }
+
+        // Hard Delete
+        storeRepository.delete(store);
+        return ApiResponse.success();
+    }
+
+    // 사용자 주소 기반 가게 조회 (고객용)
+    public ApiResponse<List<StoreResponseDto>> getStoresByUserAddress(String username) {
+        // 사용자의 주소 조회 (가장 최근 주소)
+        List<UserAddress> userAddresses = userAddressRepository.findByUserUsernameOrderByCreatedAtDesc(username);
+        
+        if (userAddresses.isEmpty()) {
+            return ApiResponse.success(List.of());
+        }
+        
+        // 가장 최근 주소의 city로 가게 조회
+        String userCity = userAddresses.get(0).getCity();
+        List<Store> stores = storeRepository.findByCityAndDeletedAtIsNull(userCity);
+        
+        List<StoreResponseDto> responseDtos = stores.stream()
+                .map(StoreResponseDto::fromEntity)
+                .toList();
+        
+        return ApiResponse.success(responseDtos);
+    }
+}

--- a/src/main/java/com/f1/fastone/user/entity/User.java
+++ b/src/main/java/com/f1/fastone/user/entity/User.java
@@ -79,4 +79,8 @@ public class User extends BaseEntity {
         this.isPublic = isPublic;
     }
 
+    public void updateRole(UserRole role) {
+        this.role = role;
+    }
+
 }

--- a/src/test/java/com/f1/fastone/store/service/StoreServiceTest.java
+++ b/src/test/java/com/f1/fastone/store/service/StoreServiceTest.java
@@ -1,0 +1,370 @@
+package com.f1.fastone.store.service;
+
+import com.f1.fastone.common.dto.ApiResponse;
+import com.f1.fastone.common.exception.custom.EntityNotFoundException;
+import com.f1.fastone.store.dto.request.StoreCreateRequestDto;
+import com.f1.fastone.store.dto.request.StoreUpdateRequestDto;
+import com.f1.fastone.store.dto.response.StoreResponseDto;
+import com.f1.fastone.store.entity.Store;
+import com.f1.fastone.store.entity.StoreCategory;
+import com.f1.fastone.store.repository.StoreCategoryRepository;
+import com.f1.fastone.store.repository.StoreRepository;
+import com.f1.fastone.user.entity.User;
+import com.f1.fastone.user.entity.UserRole;
+import com.f1.fastone.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+class StoreServiceTest {
+
+    @InjectMocks
+    private StoreService storeService;
+
+    @Mock
+    private StoreRepository storeRepository;
+    @Mock
+    private StoreCategoryRepository storeCategoryRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private User testUser;
+    private Store testStore;
+    private StoreCategory testCategory;
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+
+        testUser = User.builder()
+                .username("testuser")
+                .email("test@example.com")
+                .password("password")
+                .role(UserRole.CUSTOMER)
+                .build();
+
+        testCategory = StoreCategory.builder()
+                .id(1L)
+                .storeCategoryName("한식")
+                .build();
+
+        testStore = Store.builder()
+                .id(UUID.randomUUID())
+                .name("테스트 가게")
+                .phone("010-1234-5678")
+                .postalCode("12345")
+                .city("Seoul")
+                .address("강남구 역삼동")
+                .addressDetail("101호")
+                .latitude(BigDecimal.valueOf(37.5665))
+                .longitude(BigDecimal.valueOf(126.9780))
+                .openTime(LocalTime.of(9, 0))
+                .closeTime(LocalTime.of(22, 0))
+                .owner(testUser)
+                .category(testCategory)
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (closeable != null) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    @DisplayName("가게 생성 성공: CUSTOMER → OWNER 승격 포함")
+    void createStore_success_customerToOwner() {
+        // given
+        String username = "testuser";
+        StoreCreateRequestDto requestDto = new StoreCreateRequestDto(
+                "테스트 가게", "010-1234-5678", "12345", "Seoul",
+                "강남구 역삼동", "101호", BigDecimal.valueOf(37.5665),
+                BigDecimal.valueOf(126.9780), LocalTime.of(9, 0),
+                LocalTime.of(22, 0), null
+        );
+
+        given(userRepository.findByUsername(username)).willReturn(Optional.of(testUser));
+        given(storeRepository.save(any(Store.class))).willReturn(testStore);
+
+        // when
+        ApiResponse<StoreResponseDto> result = storeService.createStore(username, requestDto);
+
+        // then
+        assertThat(result.data()).isNotNull();
+        assertThat(result.data().name()).isEqualTo("테스트 가게");
+        assertThat(testUser.getRole()).isEqualTo(UserRole.OWNER);
+
+        then(userRepository).should(times(1)).findByUsername(username);
+        then(storeRepository).should(times(1)).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("가게 생성 성공: 이미 OWNER인 경우")
+    void createStore_success_alreadyOwner() {
+        // given
+        testUser = User.builder()
+                .username("testuser")
+                .email("test@example.com")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
+
+        String username = "testuser";
+        StoreCreateRequestDto requestDto = new StoreCreateRequestDto(
+                "테스트 가게", "010-1234-5678", "12345", "Seoul",
+                "강남구 역삼동", "101호", BigDecimal.valueOf(37.5665),
+                BigDecimal.valueOf(126.9780), LocalTime.of(9, 0),
+                LocalTime.of(22, 0), null
+        );
+
+        given(userRepository.findByUsername(username)).willReturn(Optional.of(testUser));
+        given(storeRepository.save(any(Store.class))).willReturn(testStore);
+
+        // when
+        ApiResponse<StoreResponseDto> result = storeService.createStore(username, requestDto);
+
+        // then
+        assertThat(result.data()).isNotNull();
+        assertThat(testUser.getRole()).isEqualTo(UserRole.OWNER);
+
+        then(userRepository).should(times(1)).findByUsername(username);
+        then(storeRepository).should(times(1)).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("가게 생성 실패: 사용자 없음")
+    void createStore_fail_userNotFound() {
+        // given
+        String username = "nonexistent";
+        StoreCreateRequestDto requestDto = new StoreCreateRequestDto(
+                "테스트 가게", "010-1234-5678", "12345", "Seoul",
+                "강남구 역삼동", "101호", BigDecimal.valueOf(37.5665),
+                BigDecimal.valueOf(126.9780), LocalTime.of(9, 0),
+                LocalTime.of(22, 0), null
+        );
+
+        given(userRepository.findByUsername(username)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> storeService.createStore(username, requestDto))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("유저를 찾을 수 없습니다");
+
+        then(storeRepository).should(never()).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("가게 단일 조회 성공")
+    void getStore_success() {
+        // given
+        UUID storeId = testStore.getId();
+        given(storeRepository.findByIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(testStore));
+
+        // when
+        ApiResponse<StoreResponseDto> result = storeService.getStore(storeId);
+
+        // then
+        assertThat(result.data()).isNotNull();
+        assertThat(result.data().name()).isEqualTo("테스트 가게");
+
+        then(storeRepository).should(times(1)).findByIdAndDeletedAtIsNull(storeId);
+    }
+
+    @Test
+    @DisplayName("가게 단일 조회 실패: 존재하지 않는 ID")
+    void getStore_fail_notFound() {
+        // given
+        UUID nonExistentId = UUID.randomUUID();
+        given(storeRepository.findByIdAndDeletedAtIsNull(nonExistentId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> storeService.getStore(nonExistentId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("스토어를 찾을 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("가게 전체 조회 성공")
+    void getAllStores_success() {
+        // given
+        User user1 = User.builder().username("user1").email("user1@test.com").password("password").role(UserRole.CUSTOMER).build();
+        User user2 = User.builder().username("user2").email("user2@test.com").password("password").role(UserRole.CUSTOMER).build();
+        
+        Store store1 = Store.builder().id(UUID.randomUUID()).name("가게1").owner(user1).build();
+        Store store2 = Store.builder().id(UUID.randomUUID()).name("가게2").owner(user2).build();
+        List<Store> stores = Arrays.asList(store1, store2);
+
+        given(storeRepository.findAllByDeletedAtIsNull()).willReturn(stores);
+
+        // when
+        ApiResponse<List<StoreResponseDto>> result = storeService.getAllStores();
+
+        // then
+        assertThat(result.data()).hasSize(2);
+        assertThat(result.data().get(0).name()).isEqualTo("가게1");
+        assertThat(result.data().get(1).name()).isEqualTo("가게2");
+
+        then(storeRepository).should(times(1)).findAllByDeletedAtIsNull();
+    }
+
+    @Test
+    @DisplayName("가게 수정 성공: owner 본인")
+    void updateStore_success_owner() {
+        // given
+        String username = "testuser";
+        UUID storeId = testStore.getId();
+        StoreUpdateRequestDto requestDto = new StoreUpdateRequestDto(
+                "수정된 가게", "010-9999-9999", "54321", "Busan",
+                "해운대구", "202호", BigDecimal.valueOf(35.1796),
+                BigDecimal.valueOf(129.0756), LocalTime.of(10, 0),
+                LocalTime.of(23, 0), null
+        );
+
+        given(userRepository.findByUsername(username)).willReturn(Optional.of(testUser));
+        given(storeRepository.findByIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(testStore));
+        given(storeRepository.save(any(Store.class))).willReturn(testStore);
+
+        // when
+        ApiResponse<StoreResponseDto> result = storeService.updateStore(username, storeId, requestDto);
+
+        // then
+        assertThat(result.data()).isNotNull();
+        assertThat(result.data().name()).isEqualTo("수정된 가게");
+
+        then(userRepository).should(times(1)).findByUsername(username);
+        then(storeRepository).should(times(1)).findByIdAndDeletedAtIsNull(storeId);
+        then(storeRepository).should(times(1)).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("가게 수정 성공: MANAGER")
+    void updateStore_success_manager() {
+        // given
+        User manager = User.builder()
+                .username("manager")
+                .email("manager@example.com")
+                .password("password")
+                .role(UserRole.MANAGER)
+                .build();
+
+        String username = "manager";
+        UUID storeId = testStore.getId();
+        StoreUpdateRequestDto requestDto = new StoreUpdateRequestDto(
+                "수정된 가게", "010-9999-9999", "54321", "Busan",
+                "해운대구", "202호", BigDecimal.valueOf(35.1796),
+                BigDecimal.valueOf(129.0756), LocalTime.of(10, 0),
+                LocalTime.of(23, 0), null
+        );
+
+        given(userRepository.findByUsername(username)).willReturn(Optional.of(manager));
+        given(storeRepository.findByIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(testStore));
+        given(storeRepository.save(any(Store.class))).willReturn(testStore);
+
+        // when
+        ApiResponse<StoreResponseDto> result = storeService.updateStore(username, storeId, requestDto);
+
+        // then
+        assertThat(result.data()).isNotNull();
+        assertThat(result.data().name()).isEqualTo("수정된 가게");
+
+        then(userRepository).should(times(1)).findByUsername(username);
+        then(storeRepository).should(times(1)).findByIdAndDeletedAtIsNull(storeId);
+        then(storeRepository).should(times(1)).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("가게 수정 실패: 권한 없음")
+    void updateStore_fail_accessDenied() {
+        // given
+        User otherUser = User.builder()
+                .username("otheruser")
+                .email("other@example.com")
+                .password("password")
+                .role(UserRole.CUSTOMER)
+                .build();
+
+        String username = "otheruser";
+        UUID storeId = testStore.getId();
+        StoreUpdateRequestDto requestDto = new StoreUpdateRequestDto(
+                "수정된 가게", "010-9999-9999", "54321", "Busan",
+                "해운대구", "202호", BigDecimal.valueOf(35.1796),
+                BigDecimal.valueOf(129.0756), LocalTime.of(10, 0),
+                LocalTime.of(23, 0), null
+        );
+
+        given(userRepository.findByUsername(username)).willReturn(Optional.of(otherUser));
+        given(storeRepository.findByIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(testStore));
+
+        // when & then
+        assertThatThrownBy(() -> storeService.updateStore(username, storeId, requestDto))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("해당 리소스에 접근할 권한이 없습니다");
+
+        then(storeRepository).should(never()).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("가게 삭제 성공")
+    void deleteStore_success() {
+        // given
+        String username = "testuser";
+        UUID storeId = testStore.getId();
+
+        given(userRepository.findByUsername(username)).willReturn(Optional.of(testUser));
+        given(storeRepository.findByIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(testStore));
+        willDoNothing().given(storeRepository).delete(testStore);
+
+        // when
+        ApiResponse<Void> result = storeService.deleteStore(username, storeId);
+
+        // then
+        assertThat(result.data()).isNull();
+
+        then(userRepository).should(times(1)).findByUsername(username);
+        then(storeRepository).should(times(1)).findByIdAndDeletedAtIsNull(storeId);
+        then(storeRepository).should(times(1)).delete(testStore);
+    }
+
+    @Test
+    @DisplayName("가게 삭제 실패: 권한 없음")
+    void deleteStore_fail_accessDenied() {
+        // given
+        User otherUser = User.builder()
+                .username("otheruser")
+                .email("other@example.com")
+                .password("password")
+                .role(UserRole.CUSTOMER)
+                .build();
+
+        String username = "otheruser";
+        UUID storeId = testStore.getId();
+
+        given(userRepository.findByUsername(username)).willReturn(Optional.of(otherUser));
+        given(storeRepository.findByIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(testStore));
+
+        // when & then
+        assertThatThrownBy(() -> storeService.deleteStore(username, storeId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("해당 리소스에 접근할 권한이 없습니다");
+
+        then(storeRepository).should(never()).delete(any(Store.class));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #19 #23 

## 📝작업 내용
- CREATE: CUSTOMER가 가게 생성 시 OWNER로 승격
- READ
  - 단일 상세: 모든 로그인 유저
  - 내 지역 목록: 로그인 유저의 최근 주소 city 기준 필터(detail address로 변동 가능성 있음)
  - 전체 목록(관리자용): MANAGER/MASTER만
- UPDATE/DELETE: OWNER, MANAGER, MASTER
- 테스트 코드 작성

## 💬리뷰 요구사항
> 타 팀원 코드 파일 변동 사항: User.java에 UserRole Update 메서드(updateRole) 추가되었습니다.