### PR TITLE
[FEAT] Payment 엔티티 추가 및 부가 기능 추가

### DIFF
--- a/src/main/java/com/f1/fastone/cart/controller/CartController.java
+++ b/src/main/java/com/f1/fastone/cart/controller/CartController.java
@@ -5,6 +5,7 @@ import com.f1.fastone.cart.dto.request.ItemUpdateRequestDto;
 import com.f1.fastone.cart.dto.response.CartResponseDto;
 import com.f1.fastone.cart.dto.response.ItemCreateResponseDto;
 import com.f1.fastone.cart.service.CartService;
+import com.f1.fastone.common.auth.security.UserDetailsImpl;
 import com.f1.fastone.common.dto.ApiResponse;
 import java.util.List;
 import java.util.UUID;
@@ -21,14 +22,14 @@ public class CartController {
     private final CartService cartService;
 
     @PostMapping("/store/{storeId}/items")
-    public ApiResponse<ItemCreateResponseDto> addItem(@AuthenticationPrincipal UserDetails user,
+    public ApiResponse<ItemCreateResponseDto> addItem(@AuthenticationPrincipal UserDetailsImpl user,
                                                       @PathVariable UUID storeId,
                                                       @RequestBody ItemCreateRequestDto requestDto) {
         return ApiResponse.success(cartService.addItem(user.getUsername(), storeId, requestDto));
     }
 
     @PatchMapping("/store/{storeId}/items/{menuId}")
-    public ApiResponse<Void> updateQuantity(@AuthenticationPrincipal UserDetails user,
+    public ApiResponse<Void> updateQuantity(@AuthenticationPrincipal UserDetailsImpl user,
                                             @PathVariable UUID storeId,
                                             @PathVariable String menuId,
                                             @RequestBody ItemUpdateRequestDto request) {
@@ -37,7 +38,7 @@ public class CartController {
     }
 
     @DeleteMapping("/store/{storeId}/items/{menuId}")
-    public ApiResponse<Void> removeItem(@AuthenticationPrincipal UserDetails user,
+    public ApiResponse<Void> removeItem(@AuthenticationPrincipal UserDetailsImpl user,
                                         @PathVariable UUID storeId,
                                         @PathVariable String menuId) {
         cartService.removeItem(user.getUsername(), storeId, menuId);
@@ -45,7 +46,7 @@ public class CartController {
     }
 
     @DeleteMapping("/store/{storeId}")
-    public ApiResponse<Void> clearCart(@AuthenticationPrincipal UserDetails user,
+    public ApiResponse<Void> clearCart(@AuthenticationPrincipal UserDetailsImpl user,
                                        @PathVariable UUID storeId) {
         cartService.clearCart(user.getUsername(), storeId);
         return ApiResponse.success();
@@ -53,7 +54,7 @@ public class CartController {
 
     @GetMapping()
     public ApiResponse<List<CartResponseDto>> getCart(
-            @AuthenticationPrincipal UserDetails user) {
+            @AuthenticationPrincipal UserDetailsImpl user) {
         return ApiResponse.success(cartService.getCart(user.getUsername()));
     }
 }

--- a/src/main/java/com/f1/fastone/cart/dto/CartRedisItem.java
+++ b/src/main/java/com/f1/fastone/cart/dto/CartRedisItem.java
@@ -1,0 +1,25 @@
+package com.f1.fastone.cart.dto;
+
+import com.f1.fastone.menu.entity.Menu;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public record CartRedisItem(
+        String n,
+        String img,
+        int p,
+        int q,
+        long a
+) {
+    public static CartRedisItem from(Menu menu, int quantity, LocalDateTime addedAt) {
+        return new CartRedisItem(menu.getName(), menu.getImageUrl(), menu.getPrice(), quantity, addedAt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+    }
+
+    public static CartRedisItem updateQuantity(CartRedisItem original, int newQuantity) {
+        return new CartRedisItem(original.n(), original.img(), original.p(), newQuantity, original.a());
+    }
+
+    public static CartRedisItem updateFrom(CartRedisItem original, Menu menu) {
+        return new CartRedisItem(menu.getName(), menu.getImageUrl(), menu.getPrice(), original.q, original.a);
+    }
+}

--- a/src/main/java/com/f1/fastone/cart/dto/response/CartItemResponseDto.java
+++ b/src/main/java/com/f1/fastone/cart/dto/response/CartItemResponseDto.java
@@ -1,30 +1,24 @@
 package com.f1.fastone.cart.dto.response;
 
+import com.f1.fastone.cart.dto.CartRedisItem;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Map;
+import java.util.UUID;
 
 public record CartItemResponseDto(
-        String menuId,
+        UUID menuId,
         String menuName,
         String imageUrl,
-        long priceSnapshot,
+        long price,
         int quantity,
         LocalDateTime addedAt
 ) {
-    public static CartItemResponseDto from(String menuId, Map<String, Object> map) {
+    public static CartItemResponseDto from(UUID menuId, CartRedisItem item) {
         LocalDateTime addedAt = LocalDateTime.ofInstant(
-                Instant.ofEpochMilli(((Number) map.get("a")).longValue()),
+                Instant.ofEpochMilli(item.a()),
                 ZoneId.systemDefault()
         );
-        return new CartItemResponseDto(
-                menuId,
-                (String) map.get("n"),
-                (String) map.get("img"),
-                ((Number) map.get("p")).longValue(),
-                ((Number) map.get("q")).intValue(),
-                addedAt
-        );
+        return new CartItemResponseDto(menuId, item.n(), item.img(), item.p(), item.q(), addedAt);
     }
 }

--- a/src/main/java/com/f1/fastone/cart/service/CartService.java
+++ b/src/main/java/com/f1/fastone/cart/service/CartService.java
@@ -1,27 +1,30 @@
 package com.f1.fastone.cart.service;
 
 import com.f1.fastone.cart.dto.request.ItemCreateRequestDto;
+import com.f1.fastone.cart.dto.response.CartItemResponseDto;
 import com.f1.fastone.cart.dto.response.CartResponseDto;
 import com.f1.fastone.cart.dto.response.ItemCreateResponseDto;
 import com.f1.fastone.cart.repository.CartRepository;
+import com.f1.fastone.common.exception.custom.ServiceException;
 import com.f1.fastone.menu.entity.Menu;
 import com.f1.fastone.menu.repository.MenuRepository;
 import com.f1.fastone.common.exception.ErrorCode;
 import com.f1.fastone.common.exception.custom.EntityNotFoundException;
+import com.f1.fastone.cart.dto.CartRedisItem;
 import com.f1.fastone.store.entity.Store;
 import com.f1.fastone.store.repository.StoreRepository;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Service
 public class CartService {
-
     private final CartRepository cartRepository;
     private final StoreRepository storeRepository;
     private final MenuRepository menuRepository;
@@ -33,28 +36,51 @@ public class CartService {
         Menu menu = menuRepository.findByIdAndStoreId(requestDto.menuId(), storeId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MENU_NOT_FOUND));
 
-        Instant now = Instant.now();
-        LocalDateTime addedAt = LocalDateTime.ofInstant(now, ZoneId.systemDefault());
-        String json = String.format("{\"n\":\"%s\",\"img\":\"%s\",\"p\":%d,\"q\":%d,\"a\":%d}",
-                menu.getName(), menu.getImageUrl(), menu.getPrice(), requestDto.quantity(), now.toEpochMilli());
-        cartRepository.addMenu(userId, store, String.valueOf(requestDto.menuId()), json);
+        LocalDateTime addedAt = LocalDateTime.now();
+        CartRedisItem cartData = CartRedisItem.from(menu, requestDto.quantity(), addedAt);
+        cartRepository.addMenu(userId, store, requestDto.menuId().toString(), cartData);
 
         return ItemCreateResponseDto.from(menu, requestDto.quantity(), addedAt);
     }
 
     public void setQuantity(String userId, UUID storeId, String menuId, int quantity) {
-        cartRepository.updateQuantity(userId, String.valueOf(storeId), menuId, quantity);
+        cartRepository.updateQuantity(userId, storeId.toString(), menuId, quantity);
     }
 
     public void removeItem(String userId, UUID storeId, String menuId) {
-        cartRepository.removeMenu(userId, String.valueOf(storeId), menuId);
+        cartRepository.removeMenu(userId, storeId.toString(), menuId);
     }
 
     public void clearCart(String userId, UUID storeId) {
-        cartRepository.clearCart(userId, String.valueOf(storeId));
+        cartRepository.clearCart(userId, storeId.toString());
     }
 
     public List<CartResponseDto> getCart(String userId) {
         return cartRepository.findAllByUser(userId);
+    }
+
+    public List<CartItemResponseDto> getCartItems(String userId, UUID storeId) {
+        Map<UUID, CartRedisItem> items = cartRepository.findByUserAndStore(userId, storeId.toString());
+        if (items == null || items.isEmpty()) throw new ServiceException(ErrorCode.CART_NOT_FOUND);
+
+        List<UUID> menuIds = new ArrayList<>(items.keySet());
+        Map<UUID, Menu> menuMap = menuRepository.findAllById(menuIds).stream().collect(Collectors.toMap(Menu::getId, m -> m));
+
+        List<CartItemResponseDto> result = new ArrayList<>();
+        items.forEach((menuId, redisItem) -> {
+            Menu menu = menuMap.get(menuId);
+            if (menu == null || menu.isSoldOut()) throw new ServiceException(ErrorCode.MENU_NOT_FOUND, "존재하지 않거나 판매 중단된 메뉴입니다.");
+
+            // 가격 불일치 시 Redis 갱신
+            if (menu.getPrice() != redisItem.p()) {
+                CartRedisItem updatedRedisItem = CartRedisItem.updateFrom(redisItem, menu);
+                cartRepository.updateMenu(userId, storeId.toString(), menuId.toString(), updatedRedisItem);
+                redisItem = updatedRedisItem;
+            }
+
+            result.add(CartItemResponseDto.from(menuId, redisItem));
+        });
+
+        return result;
     }
 }

--- a/src/main/java/com/f1/fastone/common/aop/RedisExceptionHandlerAspect.java
+++ b/src/main/java/com/f1/fastone/common/aop/RedisExceptionHandlerAspect.java
@@ -23,9 +23,6 @@ public class RedisExceptionHandlerAspect {
         } catch (RedisConnectionFailureException e) {
             log.error("[Redis 연결 오류] {} - {}", joinPoint.getSignature(), e.getMessage());
             throw new InternalServerException(ErrorCode.REDIS_CONNECTION_ERROR);
-        } catch (JsonProcessingException e) {
-            log.error("[Redis 데이터 직렬화 오류] {} - {}", joinPoint.getSignature(), e.getMessage());
-            throw new InternalServerException(ErrorCode.REDIS_DATA_CORRUPTED);
         } catch (DataAccessException e) {
             log.error("[Redis 데이터 접근 오류] {} - {}", joinPoint.getSignature(), e.getMessage());
             throw new InternalServerException(ErrorCode.REDIS_OPERATION_FAILED);

--- a/src/main/java/com/f1/fastone/common/exception/ErrorCode.java
+++ b/src/main/java/com/f1/fastone/common/exception/ErrorCode.java
@@ -17,11 +17,13 @@ public enum ErrorCode {
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "A002", "유효하지 않은 토큰입니다."),
     AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "A003", "만료된 토큰입니다."),
 
+    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "AD001", "대표 주소를 찾을 수 없습니다."),
 
     //store
     STORE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "S201", "요청한 가게 카테고리를 찾을 수 없습니다."),
     STORE_CATEGORY_DUPLICATED(HttpStatus.CONFLICT.value(), "S202", "이미 존재하는 가게 카테고리 이름입니다."),
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "S001", "스토어를 찾을 수 없습니다."),
+    STORE_CLOSED(HttpStatus.BAD_REQUEST.value(), "S002", "현재 영업 중이 아닌 스토어입니다."),
 
     //menu
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "M001", "메뉴를 찾을 수 없습니다."),

--- a/src/main/java/com/f1/fastone/common/exception/ErrorCode.java
+++ b/src/main/java/com/f1/fastone/common/exception/ErrorCode.java
@@ -43,6 +43,10 @@ public enum ErrorCode {
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "O001", "주문을 찾을 수 없습니다."),
     ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "O002", "본인 주문에만 리뷰를 작성할 수 있습니다."),
 
+    // payment
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "P001", "결제 정보를 찾을 수 없습니다."),
+    INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST.value(), "P002", "결제 금액이 일치하지 않습니다."),
+
     //cart
     CART_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "CA001", "장바구니를 찾을 수 없습니다."),
     CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "CA002", "장바구니에 해당 메뉴가 존재하지 않습니다."),

--- a/src/main/java/com/f1/fastone/order/controller/OrderController.java
+++ b/src/main/java/com/f1/fastone/order/controller/OrderController.java
@@ -22,12 +22,12 @@ public class OrderController {
 
     private final OrderService orderService;
 
-    @PostMapping("")
-    public ApiResponse<OrderResponseDto> createOrder(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                     @RequestBody OrderRequestDto requestDto) {
-        OrderResponseDto response = orderService.createOrder(userDetails.getUsername(), requestDto);
-        return ApiResponse.created(response);
-    }
+//    @PostMapping("")
+//    public ApiResponse<OrderResponseDto> createOrder(@AuthenticationPrincipal UserDetailsImpl userDetails,
+//                                                     @RequestBody OrderRequestDto requestDto) {
+//        OrderResponseDto response = orderService.createOrder(userDetails.getUsername(), requestDto);
+//        return ApiResponse.created(response);
+//    }
 
     @GetMapping("")
     public ApiResponse<List<OrderResponseDto>> getOrders(@AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/f1/fastone/order/controller/OrderController.java
+++ b/src/main/java/com/f1/fastone/order/controller/OrderController.java
@@ -2,7 +2,6 @@ package com.f1.fastone.order.controller;
 
 import com.f1.fastone.common.auth.security.UserDetailsImpl;
 import com.f1.fastone.common.dto.ApiResponse;
-import com.f1.fastone.order.dto.request.OrderRequestDto;
 import com.f1.fastone.order.dto.request.OrderStatusRequestDto;
 import com.f1.fastone.order.dto.response.OrderDetailResponseDto;
 import com.f1.fastone.order.dto.response.OrderResponseDto;
@@ -21,13 +20,6 @@ import java.util.UUID;
 public class OrderController {
 
     private final OrderService orderService;
-
-//    @PostMapping("")
-//    public ApiResponse<OrderResponseDto> createOrder(@AuthenticationPrincipal UserDetailsImpl userDetails,
-//                                                     @RequestBody OrderRequestDto requestDto) {
-//        OrderResponseDto response = orderService.createOrder(userDetails.getUsername(), requestDto);
-//        return ApiResponse.created(response);
-//    }
 
     @GetMapping("")
     public ApiResponse<List<OrderResponseDto>> getOrders(@AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/f1/fastone/order/entity/Order.java
+++ b/src/main/java/com/f1/fastone/order/entity/Order.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 
 @Entity
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_orders")
@@ -62,26 +63,6 @@ public class Order extends BaseEntity {
 
     @OneToOne(mappedBy = "order")
     private Review review;
-
-    @Builder
-    public Order(OrderStatus status, int totalPrice, String requestNote, String shipToName, String shipToPhone,
-                 String postalCode, String city, String address, String addressDetail, User user, Store store,
-                 List<OrderItem> orderItems) {
-        this.status = status != null ? status : OrderStatus.CREATED;
-        this.totalPrice = totalPrice;
-        this.requestNote = requestNote;
-        this.shipToName = shipToName;
-        this.shipToPhone = shipToPhone;
-        this.postalCode = postalCode;
-        this.city = city;
-        this.address = address;
-        this.addressDetail = addressDetail;
-        this.user = user;
-        this.store = store;
-        this.orderItems = Optional.ofNullable(orderItems)
-                .orElseGet(ArrayList::new);
-        this.orderItems.forEach(orderItem -> orderItem.setOrder(this));
-    }
 
     public static Order create(User user, Payment payment, UserAddress userAddress) {
         return Order.builder()

--- a/src/main/java/com/f1/fastone/order/service/OrderService.java
+++ b/src/main/java/com/f1/fastone/order/service/OrderService.java
@@ -1,13 +1,12 @@
 package com.f1.fastone.order.service;
 
-import com.f1.fastone.cart.entity.Cart;
-import com.f1.fastone.cart.entity.CartItem;
-import com.f1.fastone.cart.repository.CartRepository;
+import com.f1.fastone.cart.dto.response.CartItemResponseDto;
 import com.f1.fastone.common.auth.security.UserDetailsImpl;
 import com.f1.fastone.common.exception.ErrorCode;
 import com.f1.fastone.common.exception.custom.EntityNotFoundException;
 import com.f1.fastone.common.exception.custom.ServiceException;
 import com.f1.fastone.menu.entity.Menu;
+import com.f1.fastone.menu.repository.MenuRepository;
 import com.f1.fastone.order.dto.OrderItemDto;
 import com.f1.fastone.order.dto.PaymentDto;
 import com.f1.fastone.order.dto.ShipToDto;
@@ -19,13 +18,18 @@ import com.f1.fastone.order.entity.OrderItem;
 import com.f1.fastone.order.entity.OrderStatus;
 import com.f1.fastone.order.repository.OrderItemRepository;
 import com.f1.fastone.order.repository.OrderRepository;
+import com.f1.fastone.payment.entity.Payment;
 import com.f1.fastone.store.entity.Store;
-import com.f1.fastone.order.dto.request.OrderRequestDto;
 import com.f1.fastone.store.repository.StoreRepository;
 import com.f1.fastone.user.entity.User;
+import com.f1.fastone.user.entity.UserAddress;
+import com.f1.fastone.user.repository.UserAddressRepository;
 import com.f1.fastone.user.entity.UserRole;
 import com.f1.fastone.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -42,33 +46,27 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class OrderService {
 
-    private final CartRepository cartRepository;
     private final StoreRepository storeRepository;
     private final OrderRepository orderRepository;
     private final UserRepository userRepository;
     private final OrderItemRepository orderItemRepository;
+    private final MenuRepository menuRepository;
+    private final UserAddressRepository userAddressRepository;
 
-//    @Transactional
-//    public OrderResponseDto createOrder(String username, OrderRequestDto requestDto) {
-//        // User(CUSTOMER), 가게, 장바구니 조회
-//        User user = userRepository.findByUsername(username).orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
-//        Store store = storeRepository.findById(requestDto.getStoreId()).orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_NOT_FOUND));
-//        Cart cart = cartRepository.findById(requestDto.getCartId()).orElseThrow(() -> new EntityNotFoundException(ErrorCode.CART_NOT_FOUND));
-//
-//        // Order 생성
-//        Order order = requestDto.toEntity(user, store);
-//        orderRepository.save(order);
-//
-//        // Order Item 생성
-//        List<CartItem> cartItems = cart.getItems();
-//        List<OrderItem> orderItems = convertCartToOrder(order, cartItems);
-//        List<OrderItemDto> orderItemDtos = orderItems.stream().peek(orderItemRepository::save).map(OrderItemDto::from).toList();
-//
-//        order.setOrderItems(orderItems);
-//
-//        PaymentDto paymentDto = new PaymentDto(order.getTotalPrice());
-//        return new OrderResponseDto(order.getId(), order.getCreatedAt(), order.getStore().getName(), orderItemDtos, paymentDto, order.getStatus());
-//    }
+    @Transactional(TxType.REQUIRES_NEW)
+    public void createOrderFromPayment(String username, Payment payment, List<CartItemResponseDto> cartItems) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+        UserAddress address = userAddressRepository.findById(payment.getAddressId())
+            .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ADDRESS_NOT_FOUND));
+
+        Order order = Order.create(user, payment, address);
+
+        orderRepository.save(order);
+
+        List<OrderItem> orderItems = convertCartToOrder(order, cartItems);
+        orderItemRepository.saveAll(orderItems);
+        order.setOrderItems(orderItems);
+    }
 
     @Transactional
     public List<OrderResponseDto> getOrders(String username) {
@@ -184,14 +182,25 @@ public class OrderService {
         }
     }
 
-    private List<OrderItem> convertCartToOrder(Order order, List<CartItem> cartItems) {
+    private List<OrderItem> convertCartToOrder(Order order, List<CartItemResponseDto> cartItems) {
+        List<UUID> menuIds = cartItems.stream()
+                .map(CartItemResponseDto::menuId)
+                .toList();
+
+        List<Menu> menus = menuRepository.findAllById(menuIds);
+
+        Map<UUID, Menu> menuMap = menus.stream()
+                .collect(Collectors.toMap(Menu::getId, menu -> menu));
+
         return cartItems.stream()
                 .map(cartItem -> {
-                    Menu menu = cartItem.getMenu();
+                    Menu menu = menuMap.get(cartItem.menuId());
+                    if (menu == null) throw new EntityNotFoundException(ErrorCode.MENU_NOT_FOUND);
+
                     return OrderItem.builder()
-                            .menuName(menu.getName())
-                            .quantity(cartItem.getQuantity())
-                            .price(menu.getPrice())
+                            .menuName(cartItem.menuName())
+                            .quantity(cartItem.quantity())
+                            .price((int) cartItem.price())
                             .order(order)
                             .menu(menu)
                             .build();

--- a/src/main/java/com/f1/fastone/order/service/OrderService.java
+++ b/src/main/java/com/f1/fastone/order/service/OrderService.java
@@ -48,27 +48,27 @@ public class OrderService {
     private final UserRepository userRepository;
     private final OrderItemRepository orderItemRepository;
 
-    @Transactional
-    public OrderResponseDto createOrder(String username, OrderRequestDto requestDto) {
-        // User(CUSTOMER), 가게, 장바구니 조회
-        User user = userRepository.findByUsername(username).orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
-        Store store = storeRepository.findById(requestDto.getStoreId()).orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_NOT_FOUND));
-        Cart cart = cartRepository.findById(requestDto.getCartId()).orElseThrow(() -> new EntityNotFoundException(ErrorCode.CART_NOT_FOUND));
-
-        // Order 생성
-        Order order = requestDto.toEntity(user, store);
-        orderRepository.save(order);
-
-        // Order Item 생성
-        List<CartItem> cartItems = cart.getItems();
-        List<OrderItem> orderItems = convertCartToOrder(order, cartItems);
-        List<OrderItemDto> orderItemDtos = orderItems.stream().peek(orderItemRepository::save).map(OrderItemDto::from).toList();
-
-        order.setOrderItems(orderItems);
-
-        PaymentDto paymentDto = new PaymentDto(order.getTotalPrice());
-        return new OrderResponseDto(order.getId(), order.getCreatedAt(), order.getStore().getName(), orderItemDtos, paymentDto, order.getStatus());
-    }
+//    @Transactional
+//    public OrderResponseDto createOrder(String username, OrderRequestDto requestDto) {
+//        // User(CUSTOMER), 가게, 장바구니 조회
+//        User user = userRepository.findByUsername(username).orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+//        Store store = storeRepository.findById(requestDto.getStoreId()).orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_NOT_FOUND));
+//        Cart cart = cartRepository.findById(requestDto.getCartId()).orElseThrow(() -> new EntityNotFoundException(ErrorCode.CART_NOT_FOUND));
+//
+//        // Order 생성
+//        Order order = requestDto.toEntity(user, store);
+//        orderRepository.save(order);
+//
+//        // Order Item 생성
+//        List<CartItem> cartItems = cart.getItems();
+//        List<OrderItem> orderItems = convertCartToOrder(order, cartItems);
+//        List<OrderItemDto> orderItemDtos = orderItems.stream().peek(orderItemRepository::save).map(OrderItemDto::from).toList();
+//
+//        order.setOrderItems(orderItems);
+//
+//        PaymentDto paymentDto = new PaymentDto(order.getTotalPrice());
+//        return new OrderResponseDto(order.getId(), order.getCreatedAt(), order.getStore().getName(), orderItemDtos, paymentDto, order.getStatus());
+//    }
 
     @Transactional
     public List<OrderResponseDto> getOrders(String username) {

--- a/src/main/java/com/f1/fastone/payment/controller/PaymentController.java
+++ b/src/main/java/com/f1/fastone/payment/controller/PaymentController.java
@@ -3,10 +3,12 @@ package com.f1.fastone.payment.controller;
 import com.f1.fastone.common.auth.security.UserDetailsImpl;
 import com.f1.fastone.common.dto.ApiResponse;
 import com.f1.fastone.payment.dto.request.PaymentRequestDto;
+import com.f1.fastone.payment.dto.response.PaymentPrepareResponseDto;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +21,13 @@ import com.f1.fastone.payment.service.PaymentService;
 @RequestMapping("/payments")
 public class PaymentController {
     private final PaymentService paymentService;
+
+    @GetMapping("/prepare/{storeId}")
+    public ApiResponse<PaymentPrepareResponseDto> preparePayment(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable UUID storeId) {
+        return ApiResponse.success(paymentService.preparePayment(userDetails.getUsername(), storeId));
+    }
 
     @PostMapping
     public ApiResponse<Void> createPayment(@AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/f1/fastone/payment/controller/PaymentController.java
+++ b/src/main/java/com/f1/fastone/payment/controller/PaymentController.java
@@ -2,7 +2,9 @@ package com.f1.fastone.payment.controller;
 
 import com.f1.fastone.common.auth.security.UserDetailsImpl;
 import com.f1.fastone.common.dto.ApiResponse;
+import com.f1.fastone.payment.dto.request.PaymentConfirmRequestDto;
 import com.f1.fastone.payment.dto.request.PaymentRequestDto;
+import com.f1.fastone.payment.dto.response.PaymentCreateResponseDto;
 import com.f1.fastone.payment.dto.response.PaymentPrepareResponseDto;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -30,9 +32,16 @@ public class PaymentController {
     }
 
     @PostMapping
-    public ApiResponse<Void> createPayment(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                           @RequestBody PaymentRequestDto paymentRequestDto) {
-        paymentService.createPayment(userDetails.getUsername(), paymentRequestDto);
+    public ApiResponse<PaymentCreateResponseDto> createPayment(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                               @RequestBody PaymentRequestDto paymentRequestDto) {
+        return ApiResponse.created(paymentService.createPayment(userDetails.getUsername(), paymentRequestDto));
+    }
+
+    @PostMapping("/success")
+    public ApiResponse<Void> confirmPayment(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody PaymentConfirmRequestDto requestDto) {
+        paymentService.confirmPayment(userDetails.getUsername(), requestDto);
         return ApiResponse.created();
     }
 }

--- a/src/main/java/com/f1/fastone/payment/controller/PaymentController.java
+++ b/src/main/java/com/f1/fastone/payment/controller/PaymentController.java
@@ -1,0 +1,29 @@
+package com.f1.fastone.payment.controller;
+
+import com.f1.fastone.common.auth.security.UserDetailsImpl;
+import com.f1.fastone.common.dto.ApiResponse;
+import com.f1.fastone.payment.dto.request.PaymentRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.f1.fastone.payment.service.PaymentService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/payments")
+public class PaymentController {
+    private final PaymentService paymentService;
+
+    @PostMapping
+    public ApiResponse<Void> createPayment(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                           @RequestBody PaymentRequestDto paymentRequestDto) {
+        paymentService.createPayment(userDetails.getUsername(), paymentRequestDto);
+        return ApiResponse.created();
+    }
+}

--- a/src/main/java/com/f1/fastone/payment/dto/request/PaymentConfirmRequestDto.java
+++ b/src/main/java/com/f1/fastone/payment/dto/request/PaymentConfirmRequestDto.java
@@ -1,0 +1,11 @@
+package com.f1.fastone.payment.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PaymentConfirmRequestDto(
+    String paymentKey,
+    UUID paymentId,
+    long amount,
+    LocalDateTime approvedAt
+) {}

--- a/src/main/java/com/f1/fastone/payment/dto/request/PaymentRequestDto.java
+++ b/src/main/java/com/f1/fastone/payment/dto/request/PaymentRequestDto.java
@@ -1,0 +1,9 @@
+package com.f1.fastone.payment.dto.request;
+
+import java.util.UUID;
+
+public record PaymentRequestDto(
+        UUID storeId,
+        long amount,
+        String method
+) {}

--- a/src/main/java/com/f1/fastone/payment/dto/request/PaymentRequestDto.java
+++ b/src/main/java/com/f1/fastone/payment/dto/request/PaymentRequestDto.java
@@ -5,5 +5,6 @@ import java.util.UUID;
 public record PaymentRequestDto(
         UUID storeId,
         long amount,
-        String method
+        String method,
+        long addressId
 ) {}

--- a/src/main/java/com/f1/fastone/payment/dto/response/PaymentCreateResponseDto.java
+++ b/src/main/java/com/f1/fastone/payment/dto/response/PaymentCreateResponseDto.java
@@ -1,0 +1,12 @@
+package com.f1.fastone.payment.dto.response;
+
+import com.f1.fastone.payment.entity.Payment;
+import java.util.UUID;
+
+public record PaymentCreateResponseDto(
+        UUID paymentId
+) {
+    public static PaymentCreateResponseDto from(Payment payment) {
+        return new PaymentCreateResponseDto(payment.getId());
+    }
+}

--- a/src/main/java/com/f1/fastone/payment/dto/response/PaymentPrepareResponseDto.java
+++ b/src/main/java/com/f1/fastone/payment/dto/response/PaymentPrepareResponseDto.java
@@ -1,0 +1,24 @@
+package com.f1.fastone.payment.dto.response;
+
+import com.f1.fastone.cart.dto.response.CartItemResponseDto;
+import java.util.List;
+
+public record PaymentPrepareResponseDto(
+        PaymentPrepareUserDto user,
+        String storeName,
+        List<CartItemResponseDto> cartItems,
+        long totalAmount
+) {
+    public static PaymentPrepareResponseDto of(PaymentPrepareUserDto user, String storeName, List<CartItemResponseDto> cartItems) {
+        long total = cartItems.stream()
+                .mapToLong(item -> item.price() * item.quantity())
+                .sum();
+
+        return new PaymentPrepareResponseDto(
+                user,
+                storeName,
+                cartItems,
+                total
+        );
+    }
+}

--- a/src/main/java/com/f1/fastone/payment/dto/response/PaymentPrepareUserDto.java
+++ b/src/main/java/com/f1/fastone/payment/dto/response/PaymentPrepareUserDto.java
@@ -1,0 +1,15 @@
+package com.f1.fastone.payment.dto.response;
+
+import com.f1.fastone.user.entity.User;
+import com.f1.fastone.user.entity.UserAddress;
+
+public record PaymentPrepareUserDto(
+        String nickname,
+        String phoneNumber,
+        String address
+) {
+    public static PaymentPrepareUserDto from(User user, UserAddress defaultAddress) {
+        String fullAddress = String.format("(%s) %s %s %s", defaultAddress.getPostalCode(), defaultAddress.getCity(), defaultAddress.getAddress(), defaultAddress.getAddressDetail());
+        return new PaymentPrepareUserDto(user.getNickname(), user.getPhoneNumber(), fullAddress.trim());
+    }
+}

--- a/src/main/java/com/f1/fastone/payment/entity/Payment.java
+++ b/src/main/java/com/f1/fastone/payment/entity/Payment.java
@@ -1,0 +1,84 @@
+package com.f1.fastone.payment.entity;
+
+import com.f1.fastone.common.entity.BaseEntity;
+import com.f1.fastone.payment.dto.request.PaymentRequestDto;
+import com.f1.fastone.store.entity.Store;
+import com.f1.fastone.user.entity.User;
+import com.f1.fastone.order.entity.Order;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_payment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String paymentKey; // 외부 결제 고유 키
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(nullable = false)
+    private String method; // 카드, 계좌이체 등
+
+    private String approvedAt; // 결제 완료 시각 (외부 결제사에서 내려주는 값)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @Builder
+    public Payment(long amount, String method, PaymentStatus status, User user, Store store) {
+        this.amount = amount;
+        this.method = method;
+        this.status = status;
+        this.user = user;
+        this.store = store;
+    }
+
+    public static Payment create(PaymentRequestDto request, User user, Store store) {
+        return Payment.builder()
+                .amount(request.amount())
+                .method(request.method())
+                .status(PaymentStatus.READY)
+                .user(user)
+                .store(store)
+                .build();
+    }
+
+    public void markSuccess(String paymentKey, String approvedAt) {
+        this.paymentKey = paymentKey;
+        this.status = PaymentStatus.SUCCESS;
+        this.approvedAt = approvedAt;
+    }
+
+    public void markFail() {
+        this.status = PaymentStatus.FAIL;
+    }
+
+    public void markCancel() {
+        this.status = PaymentStatus.CANCEL;
+    }
+}

--- a/src/main/java/com/f1/fastone/payment/entity/Payment.java
+++ b/src/main/java/com/f1/fastone/payment/entity/Payment.java
@@ -1,11 +1,13 @@
 package com.f1.fastone.payment.entity;
 
 import com.f1.fastone.common.entity.BaseEntity;
+import com.f1.fastone.payment.dto.request.PaymentConfirmRequestDto;
 import com.f1.fastone.payment.dto.request.PaymentRequestDto;
 import com.f1.fastone.store.entity.Store;
 import com.f1.fastone.user.entity.User;
 import com.f1.fastone.order.entity.Order;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 
 import java.util.UUID;
@@ -35,7 +37,12 @@ public class Payment extends BaseEntity {
     @Column(nullable = false)
     private String method; // 카드, 계좌이체 등
 
-    private String approvedAt; // 결제 완료 시각 (외부 결제사에서 내려주는 값)
+    private LocalDateTime approvedAt; // 결제 완료 시각 (외부 결제사에서 내려주는 값)
+
+    @Column(columnDefinition = "TEXT")
+    private String cartSnapshot;
+
+    private Long addressId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -50,28 +57,32 @@ public class Payment extends BaseEntity {
     private Order order;
 
     @Builder
-    public Payment(long amount, String method, PaymentStatus status, User user, Store store) {
+    public Payment(long amount, String method, PaymentStatus status, String cartSnapshot, Long addressId, User user, Store store) {
         this.amount = amount;
         this.method = method;
         this.status = status;
+        this.cartSnapshot = cartSnapshot;
+        this.addressId = addressId;
         this.user = user;
         this.store = store;
     }
 
-    public static Payment create(PaymentRequestDto request, User user, Store store) {
+    public static Payment create(PaymentRequestDto request, String cartSnapshot, Long addressId, User user, Store store) {
         return Payment.builder()
                 .amount(request.amount())
                 .method(request.method())
                 .status(PaymentStatus.READY)
+                .cartSnapshot(cartSnapshot)
+                .addressId(addressId)
                 .user(user)
                 .store(store)
                 .build();
     }
 
-    public void markSuccess(String paymentKey, String approvedAt) {
-        this.paymentKey = paymentKey;
+    public void markSuccess(PaymentConfirmRequestDto request) {
+        this.paymentKey = request.paymentKey();
         this.status = PaymentStatus.SUCCESS;
-        this.approvedAt = approvedAt;
+        this.approvedAt = request.approvedAt();
     }
 
     public void markFail() {

--- a/src/main/java/com/f1/fastone/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/f1/fastone/payment/entity/PaymentStatus.java
@@ -1,0 +1,9 @@
+package com.f1.fastone.payment.entity;
+
+public enum PaymentStatus {
+    READY,      // 결제 요청 전
+    PENDING,    // 결제 진행 중
+    SUCCESS,    // 결제 성공
+    FAIL,       // 결제 실패
+    CANCEL      // 결제 취소
+}

--- a/src/main/java/com/f1/fastone/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/f1/fastone/payment/repository/PaymentRepository.java
@@ -1,0 +1,11 @@
+package com.f1.fastone.payment.repository;
+
+import com.f1.fastone.payment.entity.Payment;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, UUID> {
+    Optional<Payment> findByPaymentKey(String paymentKey);
+    boolean existsByPaymentKey(String paymentKey);
+}

--- a/src/main/java/com/f1/fastone/payment/service/PaymentService.java
+++ b/src/main/java/com/f1/fastone/payment/service/PaymentService.java
@@ -1,14 +1,24 @@
 package com.f1.fastone.payment.service;
 
+import com.f1.fastone.cart.dto.response.CartItemResponseDto;
+import com.f1.fastone.cart.service.CartService;
 import com.f1.fastone.common.exception.ErrorCode;
 import com.f1.fastone.common.exception.custom.EntityNotFoundException;
+import com.f1.fastone.common.exception.custom.ServiceException;
 import com.f1.fastone.payment.dto.request.PaymentRequestDto;
+import com.f1.fastone.payment.dto.response.PaymentPrepareResponseDto;
+import com.f1.fastone.payment.dto.response.PaymentPrepareUserDto;
 import com.f1.fastone.payment.entity.Payment;
 import com.f1.fastone.payment.repository.PaymentRepository;
 import com.f1.fastone.user.entity.User;
+import com.f1.fastone.user.entity.UserAddress;
+import com.f1.fastone.user.repository.UserAddressRepository;
 import com.f1.fastone.user.repository.UserRepository;
 import com.f1.fastone.store.entity.Store;
 import com.f1.fastone.store.repository.StoreRepository;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,9 +26,32 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
+    private final CartService cartService;
     private final PaymentRepository paymentRepository;
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
+    private final UserAddressRepository userAddressRepository;
+
+    @Transactional(readOnly = true)
+    public PaymentPrepareResponseDto preparePayment(String username, UUID storeId) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_NOT_FOUND));
+
+        LocalTime now = LocalTime.now();
+        if (now.isBefore(store.getOpenTime()) || now.isAfter(store.getCloseTime())) {
+            throw new ServiceException(ErrorCode.STORE_CLOSED, "현재는 주문 가능한 시간이 아닙니다.");
+        }
+
+        List<CartItemResponseDto> cartItems = cartService.getCartItems(username, storeId);
+
+        UserAddress defaultAddress = userAddressRepository.findFirstByUserUsernameAndIsDefaultTrue(username)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ADDRESS_NOT_FOUND));
+        PaymentPrepareUserDto userDto = PaymentPrepareUserDto.from(user, defaultAddress);
+
+        return PaymentPrepareResponseDto.of(userDto, store.getName(), cartItems);
+    }
 
     @Transactional
     public void createPayment(String username, PaymentRequestDto request) {

--- a/src/main/java/com/f1/fastone/payment/service/PaymentService.java
+++ b/src/main/java/com/f1/fastone/payment/service/PaymentService.java
@@ -1,0 +1,33 @@
+package com.f1.fastone.payment.service;
+
+import com.f1.fastone.common.exception.ErrorCode;
+import com.f1.fastone.common.exception.custom.EntityNotFoundException;
+import com.f1.fastone.payment.dto.request.PaymentRequestDto;
+import com.f1.fastone.payment.entity.Payment;
+import com.f1.fastone.payment.repository.PaymentRepository;
+import com.f1.fastone.user.entity.User;
+import com.f1.fastone.user.repository.UserRepository;
+import com.f1.fastone.store.entity.Store;
+import com.f1.fastone.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+    private final PaymentRepository paymentRepository;
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public void createPayment(String username, PaymentRequestDto request) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+        Store store = storeRepository.findById(request.storeId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_NOT_FOUND));
+
+        Payment payment = Payment.create(request, user, store);
+        paymentRepository.save(payment);
+    }
+}

--- a/src/main/java/com/f1/fastone/payment/service/PaymentService.java
+++ b/src/main/java/com/f1/fastone/payment/service/PaymentService.java
@@ -5,7 +5,10 @@ import com.f1.fastone.cart.service.CartService;
 import com.f1.fastone.common.exception.ErrorCode;
 import com.f1.fastone.common.exception.custom.EntityNotFoundException;
 import com.f1.fastone.common.exception.custom.ServiceException;
+import com.f1.fastone.order.service.OrderService;
+import com.f1.fastone.payment.dto.request.PaymentConfirmRequestDto;
 import com.f1.fastone.payment.dto.request.PaymentRequestDto;
+import com.f1.fastone.payment.dto.response.PaymentCreateResponseDto;
 import com.f1.fastone.payment.dto.response.PaymentPrepareResponseDto;
 import com.f1.fastone.payment.dto.response.PaymentPrepareUserDto;
 import com.f1.fastone.payment.entity.Payment;
@@ -16,6 +19,8 @@ import com.f1.fastone.user.repository.UserAddressRepository;
 import com.f1.fastone.user.repository.UserRepository;
 import com.f1.fastone.store.entity.Store;
 import com.f1.fastone.store.repository.StoreRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
@@ -27,10 +32,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PaymentService {
     private final CartService cartService;
+    private final OrderService orderService;
     private final PaymentRepository paymentRepository;
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
     private final UserAddressRepository userAddressRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Transactional(readOnly = true)
     public PaymentPrepareResponseDto preparePayment(String username, UUID storeId) {
@@ -54,13 +61,55 @@ public class PaymentService {
     }
 
     @Transactional
-    public void createPayment(String username, PaymentRequestDto request) {
+    public PaymentCreateResponseDto createPayment(String username, PaymentRequestDto request) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
         Store store = storeRepository.findById(request.storeId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.STORE_NOT_FOUND));
 
-        Payment payment = Payment.create(request, user, store);
+        UserAddress address = userAddressRepository.findById(request.addressId())
+                .filter(a -> a.getUser().equals(user))
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ADDRESS_NOT_FOUND));
+
+        List<CartItemResponseDto> cartItems = cartService.getCartItems(username, store.getId());
+
+        String cartSnapshot;
+        try {
+            cartSnapshot = objectMapper.writeValueAsString(cartItems);
+        } catch (JsonProcessingException e) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR, "장바구니 스냅샷 직렬화에 실패했습니다.");
+        }
+
+        Payment payment = Payment.create(request, cartSnapshot, address.getId(), user, store);
+
         paymentRepository.save(payment);
+        cartService.clearCart(username, store.getId());
+
+        return PaymentCreateResponseDto.from(payment);
+    }
+
+    @Transactional
+    public void confirmPayment(String username, PaymentConfirmRequestDto request) {
+        Payment payment = paymentRepository.findById(request.paymentId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        if (!payment.getAmount().equals(request.amount())) {
+            throw new ServiceException(ErrorCode.INVALID_PAYMENT_AMOUNT);
+        }
+
+        payment.markSuccess(request);
+        paymentRepository.save(payment);
+
+        List<CartItemResponseDto> cartItems;
+        try {
+            cartItems = objectMapper.readValue(
+                    payment.getCartSnapshot(),
+                    objectMapper.getTypeFactory().constructCollectionType(List.class, CartItemResponseDto.class)
+            );
+        } catch (JsonProcessingException e) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR, "장바구니 스냅샷 파싱에 실패했습니다.");
+        }
+
+        orderService.createOrderFromPayment(username, payment, cartItems);
     }
 }

--- a/src/main/java/com/f1/fastone/user/entity/UserAddress.java
+++ b/src/main/java/com/f1/fastone/user/entity/UserAddress.java
@@ -34,18 +34,22 @@ public class UserAddress extends BaseEntity {
     @Column
     private String addressDetail;
 
+    @Column(nullable = false)
+    private boolean isDefault = false; // 기본값 여부
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder
     public UserAddress(String postalCode, String city, String address,
-                       String addressDetail, User user) {
+                       String addressDetail, User user, boolean isDefault) {
         this.postalCode = postalCode;
         this.city = city;
         this.address = address;
         this.addressDetail = addressDetail;
         this.user = user;
+        this.isDefault = isDefault;
     }
 
     // 주소 업데이트 메서드

--- a/src/main/java/com/f1/fastone/user/repository/UserAddressRepository.java
+++ b/src/main/java/com/f1/fastone/user/repository/UserAddressRepository.java
@@ -16,4 +16,7 @@ public interface UserAddressRepository extends JpaRepository<UserAddress, Long> 
 
     // 사용자의 주소 개수 조회
     long countByUserUsername(String username);
+
+    // 사용자 대표 주소 조회
+    Optional<UserAddress> findFirstByUserUsernameAndIsDefaultTrue(String username);
 }

--- a/src/test/java/com/f1/fastone/cart/service/CartServiceTest.java
+++ b/src/test/java/com/f1/fastone/cart/service/CartServiceTest.java
@@ -1,5 +1,6 @@
 package com.f1.fastone.cart.service;
 
+import com.f1.fastone.cart.dto.CartRedisItem;
 import com.f1.fastone.cart.dto.request.ItemCreateRequestDto;
 import com.f1.fastone.cart.dto.response.CartResponseDto;
 import com.f1.fastone.cart.repository.CartRepository;
@@ -68,7 +69,7 @@ class CartServiceTest {
 
         cartService.addItem("user1", storeId, request);
 
-        verify(cartRepository, times(1)).addMenu(eq("user1"), eq(store), eq(menuId.toString()), anyString());
+        verify(cartRepository, times(1)).addMenu(eq("user1"), eq(store), eq(menuId.toString()), any(CartRedisItem.class));
     }
 
     @Test


### PR DESCRIPTION
## 📝작업 내용
> Payment 엔티티 추가(결제 기능)
> 결제창에 필요한 데이터 조회 api
> 결제 진행 단계 api
> 결제 완료 단계 api -> 주문 생성까지
> 장바구니 매핑 방식 수정 및 로직 일부 변경


## 💬리뷰 요구사항(선택)

> payment 엔티티 추가 됐으니 확인 해주시고, 
> order 엔티티 컬럼 바뀐 건 없는데 일부 조금 수정했습니당
> 유저 주소 엔티티에 기본값 판별 컬럼 추가해서 확인 한번 해주세용